### PR TITLE
better handling for dynamic mac lookup

### DIFF
--- a/ipxe/ipxe-1.2.0-rc2
+++ b/ipxe/ipxe-1.2.0-rc2
@@ -1,0 +1,24 @@
+#!ipxe
+set version v1.2.0-rc2
+set base https://github.com/harvester/harvester/releases/download/${version}
+set harvesterreleasebase https://releases.rancher.com/harvester/${version}
+dhcp
+iflinkwait -t 5000
+goto ${ifname}
+:net0
+set address ${net0/mac}
+goto setupboot
+:net1
+set address ${net1/mac}
+goto setupboot
+:net2
+set address ${net2/mac}
+goto setupboot
+:net3
+set address ${net3/mac}
+goto setupboot
+
+:setupboot
+kernel ${base}/harvester-${version}-vmlinuz-amd64 initrd=harvester-${version}-initrd-amd64 ip=dhcp net.ifnames=1 rd.cos.disable rd.noverifyssl root=live:${harvesterreleasebase}/harvester-${version}-rootfs-amd64.squashfs harvester.install.management_interface.interfaces="hwAddr:${address}" harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 console=ttyS1,115200 harvester.install.automatic=true boot_cmd="echo include_ping_test=yes >> /etc/conf.d/net-online" harvester.install.config_url=https://metadata.platformequinix.com/userdata
+initrd ${base}/harvester-${version}-initrd-amd64
+boot


### PR DESCRIPTION
PR introduces additional logic to better handle correct interface detection when boot interface changes across multiple instance types.

Currently supports instances with a maximum of 4 interfaces, but this can be changed to accommodate more if needed.